### PR TITLE
FCRM-6714 Fixed issue where polygon edit doesn't show the nodes until clicked

### DIFF
--- a/src/js/provider/esri-sdk/draw.js
+++ b/src/js/provider/esri-sdk/draw.js
@@ -101,16 +101,13 @@ export class Draw {
     if (drawMode === 'vertex' && graphic) {
       sketchViewModel.layer = graphicsLayer
 
-      // Another timeout hack
-      setTimeout(() => {
-        sketchViewModel.update([graphic], {
-          tool: 'reshape',
-          enableRotation: false,
-          enableScaling: false,
-          preserveAspectRatio: false,
-          toggleToolOnClick: false
-        })
-      }, 100)
+      sketchViewModel.update(graphic, {
+        tool: 'reshape',
+        enableRotation: false,
+        enableScaling: false,
+        preserveAspectRatio: false,
+        toggleToolOnClick: false
+      })
     }
   }
 
@@ -281,6 +278,20 @@ export class Draw {
     const toolInfoType = e.toolEventInfo?.type
     const graphic = e.graphics[0]
 
+    if (e.state === 'active') {
+      const layer = this.layer
+      // Remove all graphics except the current one
+      layer.graphics.items.forEach(graphicItem => {
+        if (graphicItem !== graphic) {
+          layer.remove(graphicItem)
+        }
+      })
+      // Only add graphic if not already present
+      const exists = layer.graphics.items.includes(graphic)
+      if (!exists) {
+        layer.add(graphic)
+      }
+    }
     // Area events
     if (['reshape-stop', 'vertex-remove'].includes(toolInfoType)) {
       const area = areaOperator.execute(graphic.geometry)

--- a/tests/esri-sdk/draw.test.js
+++ b/tests/esri-sdk/draw.test.js
@@ -388,6 +388,45 @@ describe('Draw Class', () => {
       handleUpdateDelete(mockEvent)
       expect(mockEvent.cancel).toHaveBeenCalled()
     })
+
+    it('should remove invalid and add valid graphics when state is active', async () => {
+      const graphicsBad = { geometry: { ...mockGraphic.geometry } }
+      areaOperatorSpy.mockReturnValue(-1)
+      const graphicsGood = mockEvent.graphics[0]
+      const thisMockEvent = {
+        ...mockEvent,
+        state: 'active',
+        layer: {
+          graphics: { items: [graphicsBad] },
+          add: jest.fn(),
+          remove: jest.fn()
+        }
+      }
+      const drawInstance = createDrawInstance({ addGraphic: true })
+      handleUpdateDelete = drawInstance.handleUpdateDelete.bind(thisMockEvent)
+      handleUpdateDelete(thisMockEvent)
+      expect(thisMockEvent.layer.remove).toHaveBeenCalledWith(graphicsBad)
+      expect(thisMockEvent.layer.add).toHaveBeenCalledWith(graphicsGood)
+    })
+
+    it('should not change graphics when state is active and graphics are correct', async () => {
+      areaOperatorSpy.mockReturnValue(-1)
+      const graphicsGood = mockEvent.graphics[0]
+      const thisMockEvent = {
+        ...mockEvent,
+        state: 'active',
+        layer: {
+          graphics: { items: [graphicsGood] },
+          add: jest.fn(),
+          remove: jest.fn()
+        }
+      }
+      const drawInstance = createDrawInstance({ addGraphic: true })
+      handleUpdateDelete = drawInstance.handleUpdateDelete.bind(thisMockEvent)
+      handleUpdateDelete(thisMockEvent)
+      expect(thisMockEvent.layer.remove).not.toHaveBeenCalled()
+      expect(thisMockEvent.layer.add).not.toHaveBeenCalled()
+    })
   })
 
   describe('createPolygonSymbol', () => {


### PR DESCRIPTION
* main removed timeout, added extra bind

* main added an expose this method to draw

* FCRM-6714 updated esri code and ensured old graphics are deleted - thanks to claude

* FCRM-6714 reverted back to 4.31.6 of the esri code

* FCRM-6714 reverted back to 4.31.6 of the esri code

* FCRM-6714 removed need for exposeDraw

* FCRM-6714 added unit test coverage

* FCRM-6714 couple of tidy ups / fixes for standards

* FCRM-6714 changed some to includes - minor sonar issue